### PR TITLE
fix -r -n parameter overwrite

### DIFF
--- a/sync_images.py
+++ b/sync_images.py
@@ -151,7 +151,8 @@ try:
     (options, args) = getopt.getopt(sys.argv[1:], 'f:d:r:n:ih', ['file=', 'days=', 'registry=', 'namespace=', 'insecure_registry', 'help'])
 except getopt.GetoptError:
     help()
-
+namespace = DEFAULT_NAMESPACE
+registry = DEFAULT_REGISTRY
 for option in options:
     if option[0] == '-f' or option[0] == '--file':
         filename = option[1]
@@ -192,8 +193,6 @@ for line in lines:
             repo=line
             repo_names = normalize_repo(repo)
             new_repo = repo_names[2]
-            namespace = DEFAULT_NAMESPACE
-            registry = DEFAULT_REGISTRY
         else:
             repo = repos[0]
             repo_names = normalize_repo(repos[1])


### PR DESCRIPTION
原版的代码,如果启动的命令是

```
python sync_images.py -r registry.cn-shenzhen.aliyuncs.com -n xx
```
假设 images.txt 的内容为
```
gcr.io/ml-pipeline/api-server
```
那么这个镜像会被搬到阿里云.因为默认值在参数初始化之后赋值,导致结果被复写.

所以应该把变量的定义提前.
