### PR TITLE
add google-containers/k8s-dns-node-cache

### DIFF
--- a/images.txt
+++ b/images.txt
@@ -46,6 +46,7 @@ gcr.io/google-containers/minikube-nvidia-driver-installer
 gcr.io/google-containers/nvidia-gpu-device-plugin
 gcr.io/google_containers/coredns
 gcr.io/google_containers/metrics-server-amd64
+gcr.io/google-containers/k8s-dns-node-cache
 
 quay.io/kubernetes-ingress-controller/nginx-ingress-controller
 quay.io/kubernetes-service-catalog/service-catalog=registry.cn-hangzhou.aliyuncs.com/kubernetes-service-catalog/service-catalog


### PR DESCRIPTION
add google-containers/k8s-dns-node-cache for Ansible Kubespray playbook